### PR TITLE
fix: monitoring screen destination & origin inputs not overriding the value

### DIFF
--- a/lib/ui/monitoring/monitoring_controller.dart
+++ b/lib/ui/monitoring/monitoring_controller.dart
@@ -125,7 +125,9 @@ class MonitoringController extends StateNotifier<MonitoringState> {
 }
 
 final monitoringControllerProvider =
-    StateNotifierProvider<MonitoringController, MonitoringState>((ref) {
+    StateNotifierProvider.autoDispose<MonitoringController, MonitoringState>((
+      ref,
+    ) {
       return MonitoringController(
         tripRepository: ref.watch(tripRepositoryProvider),
         trafficMonitor: ref.watch(trafficMonitorProvider),


### PR DESCRIPTION
## Summary

- **Fixes #1**: The monitoring screen was showing stale origin/destination/arrive-by values when re-starting monitoring with different inputs.

## Root Cause

The `monitoringControllerProvider` was defined as a regular `StateNotifierProvider`, which meant Riverpod cached the `MonitoringController` instance across navigation cycles. When the user:

1. Started monitoring (controller created, `_loadTrip()` reads trip from SharedPreferences)
2. Stopped monitoring, navigated back to home
3. Changed inputs and started monitoring again

...the cached controller still held the **old** trip data because `_loadTrip()` (called in the constructor) never ran again.

## Fix

Changed the provider from `StateNotifierProvider` to `StateNotifierProvider.autoDispose`. This ensures the controller is disposed when the monitoring screen is no longer being watched, so a **fresh** controller is created on each navigation to `/monitoring`, reading the latest trip from SharedPreferences.

## Change

Single-line change in `lib/ui/monitoring/monitoring_controller.dart:127`:

```diff
-    StateNotifierProvider<MonitoringController, MonitoringState>((ref) {
+    StateNotifierProvider.autoDispose<MonitoringController, MonitoringState>((ref,) {
```

## Verification

- `flutter analyze` — no issues
- `flutter test` — all 23 tests pass