### PR TITLE
feat: add current location button to origin input

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
+    <!-- Location permissions for current location feature -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:label="JITA"
         android:name="${applicationName}"

--- a/lib/data/services/location_service.dart
+++ b/lib/data/services/location_service.dart
@@ -2,6 +2,8 @@ import 'dart:developer';
 
 import 'package:flutter_google_places_sdk/flutter_google_places_sdk.dart'
     as places_sdk;
+import 'package:geocoding/geocoding.dart' as geocoding;
+import 'package:geolocator/geolocator.dart';
 
 import '../models/trip.dart';
 
@@ -13,7 +15,26 @@ class PlaceResult {
   const PlaceResult({required this.displayName, required this.latLng});
 }
 
-/// Wraps [FlutterGooglePlacesSdk] for autocomplete suggestions.
+/// Exception thrown when location permission is denied by the user.
+class LocationPermissionDeniedException implements Exception {
+  final String message;
+  const LocationPermissionDeniedException(this.message);
+
+  @override
+  String toString() => 'LocationPermissionDeniedException: $message';
+}
+
+/// Exception thrown when location services are disabled on the device.
+class LocationServiceDisabledException implements Exception {
+  final String message;
+  const LocationServiceDisabledException(this.message);
+
+  @override
+  String toString() => 'LocationServiceDisabledException: $message';
+}
+
+/// Wraps [FlutterGooglePlacesSdk] for autocomplete suggestions
+/// and [Geolocator] for device GPS location.
 class LocationService {
   final places_sdk.FlutterGooglePlacesSdk _placesSdk;
 
@@ -87,5 +108,94 @@ class LocationService {
       );
       rethrow;
     }
+  }
+
+  /// Requests location permission, gets the current device position,
+  /// and reverse-geocodes it into a [PlaceResult].
+  ///
+  /// Throws [LocationServiceDisabledException] if location services are off.
+  /// Throws [LocationPermissionDeniedException] if the user denies permission.
+  Future<PlaceResult> getCurrentLocation() async {
+    log('getCurrentLocation: checking service availability', name: 'Location');
+
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      throw const LocationServiceDisabledException(
+        'Location services are disabled. Please enable them in Settings.',
+      );
+    }
+
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      log('getCurrentLocation: requesting permission', name: 'Location');
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        throw const LocationPermissionDeniedException(
+          'Location permission was denied.',
+        );
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      throw const LocationPermissionDeniedException(
+        'Location permission is permanently denied. '
+        'Please enable it in your device settings.',
+      );
+    }
+
+    log('getCurrentLocation: fetching position', name: 'Location');
+    final position = await Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+        timeLimit: Duration(seconds: 10),
+      ),
+    );
+
+    log(
+      'getCurrentLocation: got (${position.latitude}, ${position.longitude})',
+      name: 'Location',
+    );
+
+    final latLng = LatLng(
+      latitude: position.latitude,
+      longitude: position.longitude,
+    );
+
+    // Reverse geocode to get a human-readable address.
+    final displayName = await _reverseGeocode(
+      position.latitude,
+      position.longitude,
+    );
+
+    log('getCurrentLocation: resolved to "$displayName"', name: 'Location');
+
+    return PlaceResult(displayName: displayName, latLng: latLng);
+  }
+
+  /// Reverse-geocodes coordinates into a readable address string.
+  /// Falls back to raw coordinates if geocoding fails.
+  Future<String> _reverseGeocode(double latitude, double longitude) async {
+    try {
+      final placemarks = await geocoding.placemarkFromCoordinates(
+        latitude,
+        longitude,
+      );
+
+      if (placemarks.isNotEmpty) {
+        final placemark = placemarks.first;
+        // Build a concise display name from available components.
+        final parts = <String>[
+          if (placemark.street != null && placemark.street!.isNotEmpty)
+            placemark.street!,
+          if (placemark.locality != null && placemark.locality!.isNotEmpty)
+            placemark.locality!,
+        ];
+        if (parts.isNotEmpty) return parts.join(', ');
+      }
+    } catch (e) {
+      log('Reverse geocoding failed: $e', name: 'Location', level: 900);
+    }
+    // Fallback to raw coordinates.
+    return '${latitude.toStringAsFixed(4)}, ${longitude.toStringAsFixed(4)}';
   }
 }

--- a/lib/ui/home/home_controller.dart
+++ b/lib/ui/home/home_controller.dart
@@ -13,6 +13,7 @@ class HomeState {
   final PlaceResult? destination;
   final TimeOfDay? arrivalTime;
   final bool isLoading;
+  final bool isLoadingLocation;
   final String? errorMessage;
 
   const HomeState({
@@ -20,6 +21,7 @@ class HomeState {
     this.destination,
     this.arrivalTime,
     this.isLoading = false,
+    this.isLoadingLocation = false,
     this.errorMessage,
   });
 
@@ -28,6 +30,7 @@ class HomeState {
     PlaceResult? destination,
     TimeOfDay? arrivalTime,
     bool? isLoading,
+    bool? isLoadingLocation,
     String? errorMessage,
   }) {
     return HomeState(
@@ -35,6 +38,7 @@ class HomeState {
       destination: destination ?? this.destination,
       arrivalTime: arrivalTime ?? this.arrivalTime,
       isLoading: isLoading ?? this.isLoading,
+      isLoadingLocation: isLoadingLocation ?? this.isLoadingLocation,
       errorMessage: errorMessage,
     );
   }
@@ -85,6 +89,33 @@ class HomeController extends StateNotifier<HomeState> {
 
   void clearDestination() {
     state = HomeState(origin: state.origin, arrivalTime: state.arrivalTime);
+  }
+
+  /// Requests location permission, gets the current device position,
+  /// and sets it as the origin.
+  ///
+  /// Returns the [PlaceResult] on success, or `null` on failure
+  /// (with an error message set in state).
+  Future<PlaceResult?> setOriginFromCurrentLocation() async {
+    state = state.copyWith(isLoadingLocation: true, errorMessage: null);
+
+    try {
+      final place = await _locationService.getCurrentLocation();
+      state = state.copyWith(origin: place, isLoadingLocation: false);
+      return place;
+    } on LocationPermissionDeniedException catch (e) {
+      state = state.copyWith(isLoadingLocation: false, errorMessage: e.message);
+      return null;
+    } on LocationServiceDisabledException catch (e) {
+      state = state.copyWith(isLoadingLocation: false, errorMessage: e.message);
+      return null;
+    } catch (e) {
+      state = state.copyWith(
+        isLoadingLocation: false,
+        errorMessage: 'Failed to get current location: $e',
+      );
+      return null;
+    }
   }
 
   /// Validates the form and starts monitoring.

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -62,6 +62,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   controller.clearOrigin();
                   _originController.clear();
                 },
+                trailing: _CurrentLocationButton(
+                  isLoading: state.isLoadingLocation,
+                  onPressed: state.isLoadingLocation
+                      ? null
+                      : () => _useCurrentLocation(controller),
+                ),
               ),
               const SizedBox(height: 16),
 
@@ -179,6 +185,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       Navigator.of(context).pushReplacementNamed('/monitoring');
     }
   }
+
+  Future<void> _useCurrentLocation(HomeController controller) async {
+    final place = await controller.setOriginFromCurrentLocation();
+    if (place != null && mounted) {
+      _originController.text = place.displayName;
+    }
+  }
 }
 
 /// A text field with autocomplete dropdown for Google Places.
@@ -189,6 +202,7 @@ class _PlaceAutocompleteField extends StatefulWidget {
   final LocationService locationService;
   final ValueChanged<PlaceResult> onPlaceSelected;
   final VoidCallback onClear;
+  final Widget? trailing;
 
   const _PlaceAutocompleteField({
     required this.controller,
@@ -197,6 +211,7 @@ class _PlaceAutocompleteField extends StatefulWidget {
     required this.locationService,
     required this.onPlaceSelected,
     required this.onClear,
+    this.trailing,
   });
 
   @override
@@ -272,8 +287,11 @@ class _PlaceAutocompleteFieldState extends State<_PlaceAutocompleteField> {
           decoration: InputDecoration(
             labelText: widget.label,
             hintText: widget.hint,
-            suffixIcon: widget.controller.text.isNotEmpty
-                ? IconButton(
+            suffixIcon: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (widget.controller.text.isNotEmpty)
+                  IconButton(
                     icon: const Icon(Icons.clear),
                     onPressed: () {
                       widget.onClear();
@@ -284,7 +302,11 @@ class _PlaceAutocompleteFieldState extends State<_PlaceAutocompleteField> {
                       });
                     },
                   )
-                : const Icon(Icons.search),
+                else
+                  const Icon(Icons.search),
+                if (widget.trailing != null) widget.trailing!,
+              ],
+            ),
           ),
           onChanged: _onTextChanged,
         ),
@@ -325,6 +347,38 @@ class _PlaceAutocompleteFieldState extends State<_PlaceAutocompleteField> {
             ),
           ),
       ],
+    );
+  }
+}
+
+/// A button that shows a "my location" icon, or a loading spinner
+/// while the device position is being fetched.
+class _CurrentLocationButton extends StatelessWidget {
+  final bool isLoading;
+  final VoidCallback? onPressed;
+
+  const _CurrentLocationButton({
+    required this.isLoading,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return const Padding(
+        padding: EdgeInsets.all(12),
+        child: SizedBox(
+          height: 20,
+          width: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+
+    return IconButton(
+      icon: const Icon(Icons.my_location),
+      tooltip: 'Use current location',
+      onPressed: onPressed,
     );
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import flutter_local_notifications
+import geolocator_apple
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -264,6 +280,86 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
+  geocoding:
+    dependency: "direct main"
+    description:
+      name: geocoding
+      sha256: d580c801cba9386b4fac5047c4c785a4e19554f46be42f4f5e5b7deacd088a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  geocoding_android:
+    dependency: transitive
+    description:
+      name: geocoding_android
+      sha256: "1b13eca79b11c497c434678fed109c2be020b158cec7512c848c102bc7232603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  geocoding_ios:
+    dependency: transitive
+    description:
+      name: geocoding_ios
+      sha256: "18ab1c8369e2b0dcb3a8ccc907319334f35ee8cf4cfef4d9c8e23b13c65cb825"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  geocoding_platform_interface:
+    dependency: transitive
+    description:
+      name: geocoding_platform_interface
+      sha256: "8c2c8226e5c276594c2e18bfe88b19110ed770aeb7c1ab50ede570be8b92229b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: f62bcd90459e63210bbf9c35deb6a51c521f992a78de19a1fe5c11704f9530e2
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.4"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: fcb1760a50d7500deca37c9a666785c047139b5f9ee15aa5469fae7dbbe3170d
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.13"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.6"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.3"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   google_maps:
     dependency: transitive
     description:
@@ -629,6 +725,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,12 @@ dependencies:
   # Runtime permissions
   permission_handler: ^11.0.0
 
+  # Device GPS location
+  geolocator: ^13.0.2
+
+  # Reverse geocoding (coordinates to address)
+  geocoding: ^3.0.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <geolocator_windows/geolocator_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  geolocator_windows
   permission_handler_windows
 )
 


### PR DESCRIPTION
## Summary

Implements #3 — adds a "my location" button to the right of the origin input field that:

1. **Requests location permission** from the user when tapped
2. **Gets the device's current GPS position** if permission is granted
3. **Reverse-geocodes the coordinates** into a human-readable address (street + city)
4. **Auto-fills the origin input** with the resolved location

## Changes

### New dependencies (`pubspec.yaml`)
- `geolocator: ^13.0.2` — device GPS access with built-in permission handling
- `geocoding: ^3.0.0` — reverse geocoding (coordinates → address)

### Platform configuration
- **Android** (`AndroidManifest.xml`): added `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION` permissions
- **iOS**: already had `NSLocationWhenInUseUsageDescription` in `Info.plist`

### `LocationService` (`lib/data/services/location_service.dart`)
- Added `getCurrentLocation()` method that:
  - Checks if location services are enabled
  - Requests permission (or throws typed exceptions on denial)
  - Fetches current position with 10s timeout
  - Reverse-geocodes to a street/city display name (falls back to raw coords)
- Added `LocationPermissionDeniedException` and `LocationServiceDisabledException` custom exceptions

### `HomeController` (`lib/ui/home/home_controller.dart`)
- Added `isLoadingLocation` to `HomeState` for button loading feedback
- Added `setOriginFromCurrentLocation()` method with structured error handling

### `HomeScreen` (`lib/ui/home/home_screen.dart`)
- Added optional `trailing` widget parameter to `_PlaceAutocompleteField`
- Added `_CurrentLocationButton` widget (shows `Icons.my_location` or a spinner)
- Added `_useCurrentLocation()` handler in `_HomeScreenState`

## User experience
- Tap the location icon → permission dialog appears (first time only)
- Loading spinner replaces the icon while fetching
- Origin field auto-populates with the resolved address
- Error banner shows if permission denied or location services are off

Closes #3